### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/bonjourmadame.el
+++ b/bonjourmadame.el
@@ -47,6 +47,12 @@
 (require 'rx)
 (require 'web-mode nil t)
 
+(declare-function web-mode-dom-entities-replace "web-mode")
+
+(defgroup bonjourmadame nil
+  "Say \"Hello ma'am!\""
+  :group 'image)
+
 (defvar bonjourmadame--cache-dir (concat (or (getenv "XDG_CACHE_HOME") "~/.cache") "/bonjourmadame"))
 (defvar bonjourmadame--buffer-name "*Bonjour Madame*")
 (defvar bonjourmadame--base-url "http://ditesbonjouralamadame.tumblr.com")


### PR DESCRIPTION
- Define group for customize variables
- Declare function in web-mode.el by declare-function

This fixes following byte-compile warnings.

```
bonjourmadame.el:135:1:Warning: defcustom for
    `bonjourmadame-max-image-size-function' fails to specify containing group
bonjourmadame.el:135:1:Warning: defcustom for
    `bonjourmadame-max-image-size-function' fails to specify containing group

In end of data:
bonjourmadame.el:214:1:Warning: the function `web-mode-dom-entities-replace'
    is not known to be defined
```
